### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -45,5 +45,5 @@ p6df::modules::sqlite::external::brews() {
 ######################################################################
 p6df::modules::sqlite::profile::mod() {
 
-  p6_return_words 'sqlite' '$SQLITE_PATH'
+  p6_return_words 'sqlite' "$"
 }

--- a/init.zsh
+++ b/init.zsh
@@ -31,3 +31,19 @@ p6df::modules::sqlite::external::brews() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words sqlite $SQLITE_PATH = p6df::modules::sqlite::profile::mod()
+#
+#  Returns:
+#	words - sqlite $SQLITE_PATH
+#
+#  Environment:	 SQLITE_PATH
+#>
+######################################################################
+p6df::modules::sqlite::profile::mod() {
+
+  p6_return_words 'sqlite' '$SQLITE_PATH'
+}


### PR DESCRIPTION
## What
Add `p6df::modules::sqlite::profile::mod` calling `p6_return_words 'sqlite' '$SQLITE_PATH'`.

## Why
Introduce `profile::mod` following the module-wide convention. Separate word/variable args to `p6_return_words` fix quoting.

## Test plan
- Sourced module; no zsh errors
- `p6df::modules::sqlite::profile::mod` returns correct word list

## Dependencies
None