### PR TITLE
feat(profile): add SQLITE_HISTORY env var to profile mod

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -45,5 +45,5 @@ p6df::modules::sqlite::external::brews() {
 ######################################################################
 p6df::modules::sqlite::profile::mod() {
 
-  p6_return_words 'sqlite' "$"
+  p6_return_words 'sqlite' '$SQLITE_HISTORY'
 }


### PR DESCRIPTION
## What
Add `SQLITE_HISTORY` environment variable to `p6df::modules::sqlite::profile::mod()`.

## Why
The profile mod function previously returned a placeholder `"$"` with no actual env vars. `SQLITE_HISTORY` controls where SQLite stores command history and should be exported via the profile module.

## Test plan
- Reviewed diff in `init.zsh`
- Verified `SQLITE_HISTORY` is the standard env var for SQLite history file location

## Dependencies
None